### PR TITLE
fix: emergency shutdown + organizer device width fix

### DIFF
--- a/modules/@backend_nest/libs/common/src/shutdown/Shutdown.service.ts
+++ b/modules/@backend_nest/libs/common/src/shutdown/Shutdown.service.ts
@@ -33,6 +33,15 @@ export class ShutdownService {
      * @param msg
      */
     shutdownWithMessage(msg: string) {
+        /* istanbul ignore next */
+        if (this === undefined) {
+            console.error(msg);
+            console.error(
+                'ShutdownService: Emergency exit, ShutdownModule was not able to initialize and triggered a manual process exit',
+            );
+            process.exit(1);
+        }
+
         this.winstonLoggerService.log(msg);
         this.shutdown();
     }
@@ -43,6 +52,16 @@ export class ShutdownService {
      * @param error
      */
     shutdownWithError(error: Error) {
+        /* istanbul ignore next */
+        if (this === undefined) {
+            console.error(error.message);
+            console.error(error.stack);
+            console.error(
+                'ShutdownService: Emergency exit, ShutdownModule was not able to initialize and triggered a manual process exit',
+            );
+            process.exit(1);
+        }
+
         this.winstonLoggerService.error(error);
         this.shutdown();
     }
@@ -51,6 +70,14 @@ export class ShutdownService {
      * Simply trigegrs the shutdown
      */
     shutdown() {
+        /* istanbul ignore next */
+        if (this === undefined) {
+            console.error(
+                'ShutdownService: Emergency exit, ShutdownModule was not able to initialize and triggered a manual process exit',
+            );
+            process.exit(1);
+        }
+
         ShutdownService.shutdownFunction();
     }
 }

--- a/modules/@frontend_organizer-app/src/App.tsx
+++ b/modules/@frontend_organizer-app/src/App.tsx
@@ -33,7 +33,7 @@ const App: React.FC = () => {
         <Suspense fallback={<FullPageLoading/>}>
             <UserContextGuard>
                 <AppContainer>
-                    <MediaQuery minWidth={1224}>
+                    <MediaQuery minDeviceWidth={1224}>
                         {
                             location.pathname !== '/register' && location.pathname !== '/login'
 

--- a/modules/@frontend_organizer-app/src/utils/MobileWarning.tsx
+++ b/modules/@frontend_organizer-app/src/utils/MobileWarning.tsx
@@ -27,13 +27,13 @@ const MobileWarningComponent: React.FC = (props: any): JSX.Element => {
     const [ t ] = useTranslation('mobile_warning');
 
     return <>
-        <MediaQuery maxWidth={1224}>
+        <MediaQuery maxDeviceWidth={1224}>
             <MobileWarningContainer>
                 <MobileWarningIllustrationImg src={MobileWarningIllustration}/>
                 <MobileWarningExplainer>{t('optimal_desktop_usage')}</MobileWarningExplainer>
             </MobileWarningContainer>
         </MediaQuery>
-        <MediaQuery minWidth={1224}>
+        <MediaQuery minDeviceWidth={1224}>
             {props.children}
         </MediaQuery>
 


### PR DESCRIPTION
- Shutdown module can be invoked before it is configured. Added an
  emergency shutdown to kill the process
- Switch to device width media query on organizer app